### PR TITLE
Fix multiple captures and impact on nested field error links

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -5,6 +5,8 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
 
       def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, small:, classes:, form_group:, multiple:, &block)
+        fail LocalJumpError, 'no block given' unless block_given?
+
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -14,7 +14,6 @@ module GOVUKDesignSystemFormBuilder
         @classes       = classes
         @form_group    = form_group
         @multiple      = multiple
-        @block_content = capture { block.call }
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -14,7 +14,6 @@ module GOVUKDesignSystemFormBuilder
         @hint          = hint
         @classes       = classes
         @form_group    = form_group
-        @block_content = capture { block.call }
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -5,7 +5,9 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
 
       def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, inline:, small:, classes:, form_group:, &block)
-        super(builder, object_name, attribute_name)
+        fail LocalJumpError, 'no block given' unless block_given?
+
+        super(builder, object_name, attribute_name, &block)
 
         @inline        = inline
         @small         = small

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::FieldsetItem
 
         def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint:, link_errors:, multiple:, exclusive:, **kwargs, &block)
-          super(builder, object_name, attribute_name)
+          super(builder, object_name, attribute_name, &block)
 
           @value           = value
           @unchecked_value = unchecked_value

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -19,7 +19,7 @@ module GOVUKDesignSystemFormBuilder
           @html_attributes = kwargs
           @exclusive       = exclusive
 
-          conditional_content(&block)
+          conditional_content(@block_content)
         end
 
       private

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::FieldsetItem
 
         def initialize(builder, object_name, attribute_name, value, label:, hint:, link_errors:, **kwargs, &block)
-          super(builder, object_name, attribute_name)
+          super(builder, object_name, attribute_name, &block)
 
           @value           = value
           @label           = label

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
           @link_errors     = has_errors? && link_errors
           @html_attributes = kwargs
 
-          conditional_content(&block)
+          conditional_content(@block_content)
         end
 
       private

--- a/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
@@ -4,7 +4,7 @@ module GOVUKDesignSystemFormBuilder
       using PrefixableArray
 
       def html
-        safe_join([item, @conditional])
+        safe_join([item, @conditional_content])
       end
 
     private
@@ -61,9 +61,9 @@ module GOVUKDesignSystemFormBuilder
         build_id('conditional')
       end
 
-      def conditional_content(&block)
-        if (conditional_block_content = block_given? && (capture { block.call }).presence)
-          @conditional    = conditional_container(conditional_block_content)
+      def conditional_content(block_content)
+        if block_content.present?
+          @conditional_content = conditional_container(block_content)
           @conditional_id = conditional_id
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -50,10 +50,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { 'fieldset' }
     end
 
-    context 'when no block is supplied' do
-      subject { builder.send(*args) }
-      specify { expect { subject }.to raise_error(LocalJumpError, /no block given/) }
-    end
+    it_behaves_like 'a fieldset that expects arbitrary blocks of HTML'
 
     context 'when a caption is supplied' do
       let(:caption_text) { 'Personal preferences' }

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -52,7 +52,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'when no block is supplied' do
       subject { builder.send(*args) }
-      specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }
+      specify { expect { subject }.to raise_error(LocalJumpError, /no block given/) }
     end
 
     context 'when a caption is supplied' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -21,7 +21,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'when no block is supplied' do
       subject { builder.send(*args) }
-      specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }
+      specify { expect { subject }.to raise_error(LocalJumpError, /no block given/) }
     end
 
     include_examples 'HTML formatting checks'

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -19,10 +19,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     subject { builder.send(*args, &example_block) }
 
-    context 'when no block is supplied' do
-      subject { builder.send(*args) }
-      specify { expect { subject }.to raise_error(LocalJumpError, /no block given/) }
-    end
+    it_behaves_like 'a fieldset that expects arbitrary blocks of HTML'
 
     include_examples 'HTML formatting checks'
 

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -39,3 +39,29 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
     end
   end
 end
+
+shared_examples 'a fieldset that expects arbitrary blocks of HTML' do
+  context 'when no block is supplied' do
+    subject { builder.send(*args) }
+
+    specify { expect { subject }.to raise_error(LocalJumpError, /no block given/) }
+  end
+
+  context 'when block is supplied' do
+    subject { builder.send(*args, &example_block) }
+
+    let(:example_block) { proc { '<b>some content</b>' } }
+
+    specify { expect { subject }.not_to raise_error }
+    specify { expect { |b| builder.send(*args, &b) }.to yield_control.once }
+
+    context 'with render' do
+      let(:example_block) { proc { helper.render(html: '<b>rendered</b>') } }
+
+      before { allow(helper).to receive(:render) }
+      before { subject }
+
+      specify { expect(helper).to have_received(:render).once }
+    end
+  end
+end


### PR DESCRIPTION
### What
Fix multiple captures and their impact on nested field error links
 - prevent the overhead of render calls being made multiple times
 - fix the side-effect of incrementing nested field-error ids, thereby breaking links between the error summary and the fields

### Why
We have a fairly complex nested field structure for a few of our forms
and error linking using this formbuilder was not working, but works against 
this branch.

On investigation I found that partials for the nested fields were being Rendered multiple times.
This did not actually render the fields multiple times, which I still do not understand
why not, but did increment the id of the nested fields.

#### Cause
- **1. Fieldset class plus super class capture the called block**
Digging into the code I found that the `RadioButtonsFieldset` and `CheckBoxesFieldset` 
inherit from the `Base` class which captures the `block.call` themselves AND via calls to
`super()`.

  Because `super(arg1,arg2,etc)` is called, the block is passed implicitly
whether you supply it as an arg to super, `&block`, or not. This
results in the block being called and captured twice `capture { block.call }`,
once for the fieldset and once by superclass `Base`.

  In the case of a block being passed that renders a partial it
means that rails renders the partial twice which has the
side effect of incrementing the ids of fields.

  _fixed by removing the fieldset level capture and relying on inheritance_

- **2. fieldset_item block capture**
Ironically, out of a change we asked for, and you kindly supplied, there is an additional 
`capture { block.call }` in the `FieldsetItem` trait. which we are also dependent on. 

  _fixed by passing the captured content directly_

### Example

A considerably simplified version with only one fieldset might look like this 
_nb: we have [fieldsets inside fieldsets plus conditional blocks](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/master/app/views/shared/providers/_form.html.haml) which causes exponential  id incrementation issues, so that our first nested field ends up with an id of 15 instead of 0. Screenshot below_
_

```
# my_nested_fields_partial
    = f.fields_for :details, @details do |ff|
        = ff.govuk_text_field :name
```

```
# my_form_partial
= f.govuk_radio_buttons_fieldset :provider, do
    if some_condition
      = render partial: 'my_nested_fields_partial' 
```

**The resulting html**
`my_nested_fields_partial` is called twice, but only displays content once??, but does increment field-error ids so:
 id of the name field is `provider-details-attributes-1-name-field-error` while the summary error generated for it correctly links to `provider-details-attributes-0-name-field-error`
 
### Real example
We have [fieldsets inside fieldsets plus conditional blocks](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/master/app/views/shared/providers/_form.html.haml) which causes exponential  id incrementation issues, so that our first nested field ends up with an id of 15 instead of 0, the second with an id of 31.

![Screenshot 2021-07-01 at 08 41 25](https://user-images.githubusercontent.com/7016425/124085984-7fb4fc00-da48-11eb-9a8f-7dbf36d673ba.png)


#### Additional
Possibly problematic block captures exist in other classes that inherit from the `Base` class and could result in similar issues being experienced. `lib/govuk_design_system_formbuilder/elements/submit.rb` in particular. I have not changed this in this PR however as I have not experienced problems with this myself.
